### PR TITLE
add missing platform attribute

### DIFF
--- a/piggymeter-common.yaml
+++ b/piggymeter-common.yaml
@@ -26,8 +26,8 @@ api:
     key: !secret api_key
 
 ota:
-  platform: esphome
-  password: !secret ota_pass
+  - platform: esphome
+    password: !secret ota_pass
 
 external_components:
     # IEC62056-21 component

--- a/piggymeter-common.yaml
+++ b/piggymeter-common.yaml
@@ -26,6 +26,7 @@ api:
     key: !secret api_key
 
 ota:
+  platform: esphome
   password: !secret ota_pass
 
 external_components:


### PR DESCRIPTION
seems to be required by recent versions of esphome - the piggymeter-s2-sml.yaml has it as well.

https://esphome.io/components/ota/esphome.html